### PR TITLE
Изменения, необходимые для добавления поддержки плагинов опций товара

### DIFF
--- a/classes/class-ajax.php
+++ b/classes/class-ajax.php
@@ -125,8 +125,8 @@ class Ajax {
 	 */
 	protected function get_qty( int $qty = 1 ): int {
 
-		if ( ! empty( $_POST['qty'] ) ) {
-			$qty = (int) sanitize_text_field( wp_unslash( $_POST['qty'] ) );
+		if ( ! empty( $_POST['quantity'] ) ) {
+			$qty = (int) sanitize_text_field( wp_unslash( $_POST['quantity'] ) );
 		}
 
 		return $qty;

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -700,15 +700,18 @@ class Settings extends WC_Settings_Page {
 	 */
 	public static function select_elements_item(): array {
 
-		return array(
-			'title' => __( 'Title', 'art-woocommerce-order-one-click' ),
-			'image' => __( 'Image', 'art-woocommerce-order-one-click' ),
-			'price' => __( 'Price', 'art-woocommerce-order-one-click' ),
-			'sku'   => __( 'SKU', 'art-woocommerce-order-one-click' ),
-			'attr'  => __( 'Attributes', 'art-woocommerce-order-one-click' ),
-			'qty'   => __( 'Quantity', 'art-woocommerce-order-one-click' ),
-			'sum'   => __( 'Amount', 'art-woocommerce-order-one-click' ),
-		);
+		return apply_filters(
+			'awooc_select_elements_item', 
+			array(
+				'title' => __( 'Title', 'art-woocommerce-order-one-click' ),
+				'image' => __( 'Image', 'art-woocommerce-order-one-click' ),
+				'price' => __( 'Price', 'art-woocommerce-order-one-click' ),
+				'sku'   => __( 'SKU', 'art-woocommerce-order-one-click' ),
+				'attr'  => __( 'Attributes', 'art-woocommerce-order-one-click' ),
+				'qty'   => __( 'Quantity', 'art-woocommerce-order-one-click' ),
+				'sum'   => __( 'Amount', 'art-woocommerce-order-one-click' ),
+			)
+		);;
 	}
 
 

--- a/src/js/awooc-scripts.js
+++ b/src/js/awooc-scripts.js
@@ -400,7 +400,6 @@ jQuery( function ( $ ) {
 		request: function ( e ) {
 			let data = {
 				id:     AWOOC.getProductID( e ),
-				qty:    AWOOC.getQty( e ),
 				action: 'awooc_ajax_product_form',
 				nonce:  awooc_scripts_ajax.nonce
 			};
@@ -408,6 +407,10 @@ jQuery( function ( $ ) {
 			if ( $( e.target ).data( 'selected_variant' ) !== undefined ) {
 				data[ 'attributes' ] = $( e.target ).data( 'selected_variant' );
 			}
+
+			$( e.target ).closest( '.cart' ).serializeArray().forEach(function( {name, value} ) {
+			    if( !['id', 'action', 'nonce', 'attributes', 'add-to-cart'].includes( name ) ) data[name] = value;
+			});
 
 			AWOOC.xhr = $.ajax( {
 				url:      awooc_scripts_ajax.url,


### PR DESCRIPTION
– Добавил фильтр awooc_select_elements_item.
– В awooc_ajax_product_form теперь передаются все параметры из формы товара. 
– Заменил qty на quantity, так как quantity - значение из данных формы.

![изображение](https://github.com/artikus11/art-woocommerce-order-one-click/assets/39444579/1dca479a-2f39-4656-b5ce-8fcf34b0d45c)
